### PR TITLE
Test: SDK customization workflow for spec PR #41879

### DIFF
--- a/sdk/machinelearning/azure-resourcemanager-machinelearning/CHANGELOG.md
+++ b/sdk/machinelearning/azure-resourcemanager-machinelearning/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 ### Breaking Changes
 
+- TypeSpec spec PR Azure/azure-rest-api-specs#41879 restored version gating decorators that were accidentally removed.
+  This causes SDK generation changes: FineTuning-related types are now properly excluded from stable API versions
+  (2025-12-01, 2026-03-01) and preview-only features are restored in 2026-01-15-preview.
+- After regeneration, the Java SDK build fails with compilation errors due to customization drift:
+  existing customization classes reference types/operations that are no longer generated for stable versions.
+
 ### Bugs Fixed
 
 ### Other Changes


### PR DESCRIPTION
## Test PR for skill validation

This PR simulates the scenario from [Azure/azure-rest-api-specs#41879](https://github.com/Azure/azure-rest-api-specs/pull/41879) where TypeSpec version gating changes cause SDK build failures in the Java SDK.

### Context
- Spec PR ](https://github.com/Azure/azure-rest-api-specs/pull/41879) restored \@removed\ decorators for stable API versions in Azure Machine Learning TypeSpec
- After SDK regeneration, the Java SDK build fails due to customization drift (customization classes reference types no longer generated for stable versions)

### What to test
Comment \@copilot fix the build errors caused by the spec changes\ to see if the \generate-sdk-locally\ skill is triggered and invokes \zure-sdk-mcp:azsdk_customized_code_update\.

### Skill under test
